### PR TITLE
Fix page action hiding bug on Firefox

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -33,6 +33,8 @@ function initializePageAction(tab) {
     const url = new URL(tab.url);
     if (isSupportedHost(url.hostname) && isSavablePage(url.pathname, url.searchParams)) {
         browser.pageAction.show(tab.id);
+    } else {
+        browser.pageAction.hide(tab.id);
     }
 }
   


### PR DESCRIPTION
Fixes a bug in which the page action was being inappropriately shown for
non-Wikimedia pages on FF when navigating back from a Wikimedia page.

Bug: https://phabricator.wikimedia.org/T197825