### PR TITLE
Fix missing receiving end error when visiting protected pages

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -43,6 +43,8 @@ function initializePageAction(tab) {
       } else {
         browser.pageAction.hide(tab.id);
       }
+    }, err => {
+      return false
     });
 }
 


### PR DESCRIPTION
Hello,
in Firefox whenever I visit a protected page (like `addons.mozilla.org` or any `about:*` page) the console get spammed with 
```
Error: Could not establish connection. Receiving end does not exist. 2 background.js:36:18
```
This PR implements the simplest fix possible, catching and ignoring the error, which is actually expected.